### PR TITLE
Add xmltodict as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with io.open(f'{PACKAGE_ROOT}/__version__.py', 'r', encoding='utf-8') as f:
 requirements = [
     'gtfs-realtime-bindings==0.0.5',
     'pendulum==2.0.4',
+    'xmltodict==0.12.0',
 ]
 
 setup(


### PR DESCRIPTION
PR #6 added `xmltodict` only for local dev, not published packages.