### PR TITLE
TRAN-5069 : Add NJT real-time bus arrival feeds

### DIFF
--- a/gtfs_realtime_translators/registry/registry.py
+++ b/gtfs_realtime_translators/registry/registry.py
@@ -3,7 +3,7 @@ import warnings
 from gtfs_realtime_translators.translators import LaMetroGtfsRealtimeTranslator, \
     SeptaRegionalRailTranslator, MtaSubwayGtfsRealtimeTranslator, NjtRailGtfsRealtimeTranslator, \
     CtaSubwayGtfsRealtimeTranslator, CtaBusGtfsRealtimeTranslator, PathGtfsRealtimeTranslator, \
-    VtaGtfsRealtimeTranslator, WcdotGtfsRealTimeTranslator
+    VtaGtfsRealtimeTranslator, WcdotGtfsRealTimeTranslator, NjtBusGtfsRealtimeTranslator
 
 
 class TranslatorKeyWarning(Warning):
@@ -18,6 +18,7 @@ class TranslatorRegistry:
         'cta-bus': CtaBusGtfsRealtimeTranslator,
         'mta-subway': MtaSubwayGtfsRealtimeTranslator,
         'njt-rail': NjtRailGtfsRealtimeTranslator,
+        'njt-bus': NjtBusGtfsRealtimeTranslator,
         'path': PathGtfsRealtimeTranslator,
         'vta': VtaGtfsRealtimeTranslator,
         'wcdot-bus': WcdotGtfsRealTimeTranslator,

--- a/gtfs_realtime_translators/translators/__init__.py
+++ b/gtfs_realtime_translators/translators/__init__.py
@@ -2,6 +2,7 @@ from .la_metro import LaMetroGtfsRealtimeTranslator
 from .septa_regional_rail import SeptaRegionalRailTranslator
 from .mta_subway import MtaSubwayGtfsRealtimeTranslator
 from .njt_rail import NjtRailGtfsRealtimeTranslator
+from .njt_bus import NjtBusGtfsRealtimeTranslator
 from .cta_subway import CtaSubwayGtfsRealtimeTranslator
 from .cta_bus import CtaBusGtfsRealtimeTranslator
 from .path_rail import PathGtfsRealtimeTranslator

--- a/gtfs_realtime_translators/translators/njt_bus.py
+++ b/gtfs_realtime_translators/translators/njt_bus.py
@@ -1,0 +1,68 @@
+import pendulum
+import xmltodict
+import datetime
+from gtfs_realtime_translators.factories import FeedMessage, TripUpdate
+
+
+class NjtBusGtfsRealtimeTranslator:
+
+    TIMEZONE = 'America/New_York'
+
+    def __call__(self, data):
+        station_data = xmltodict.parse(data)
+        entities = self.__make_trip_updates(station_data)
+        return FeedMessage.create(entities=entities)
+
+    @classmethod
+    def __to_unix_time(cls, time):
+        dt = pendulum.from_format(
+            time, 'MM/DD/YYYY HH:mm:ss A', tz=cls.TIMEZONE).in_tz('UTC')
+        return dt
+
+    @classmethod
+    def __replace_time(cls, sched_dep_time, new_time):
+        dtime = pendulum.from_format(new_time, 'HH:mm:ss', tz=cls.TIMEZONE)
+        hour = dtime.hour
+        minute = dtime.minute
+        second = dtime.second
+        dt = pendulum.from_format(
+            sched_dep_time, 'MM/DD/YYYY HH:mm:ss A', tz=cls.TIMEZONE)
+        dt = dt.replace(hour=hour, minute=minute, second=second)
+        dt = dt.in_tz('UTC')
+        return dt
+
+    @classmethod
+    def __make_trip_updates(cls, data):
+        trip_updates = []
+        trips = data['NEXTTRIPROWSET'].values()
+
+        for value in trips:
+            for idx, item_entry in enumerate(value):
+                # Intersection Extensions
+                headsign = item_entry['header']
+                stop_id = item_entry['stop_id']
+                stop_name = item_entry['stop_name']
+                trip_id = item_entry['Trip_id']
+                route_id = item_entry['route']
+                scheduled_datetime = cls.__to_unix_time(
+                    item_entry['sched_dep_time'])
+                arrival_time = int(cls.__replace_time(
+                    item_entry['sched_dep_time'], item_entry['arrival_time']).timestamp())
+                departure_time = int(cls.__replace_time(
+                    item_entry['sched_dep_time'], item_entry['arrival_time']).timestamp())
+                scheduled_departure_time = int(scheduled_datetime.timestamp())
+
+                trip_update = TripUpdate.create(entity_id=str(idx + 1),
+                                                route_id=route_id,
+                                                trip_id=trip_id,
+                                                stop_id=stop_id,
+                                                stop_name=stop_name,
+                                                headsign=headsign,
+                                                departure_time=departure_time,
+                                                arrival_time=arrival_time,
+                                                scheduled_departure_time=scheduled_departure_time,
+                                                scheduled_arrival_time=scheduled_departure_time,
+                                                agency_timezone=cls.TIMEZONE)
+                trip_updates.append(trip_update)
+
+        return trip_updates

--- a/test/fixtures/njt_bus.xml
+++ b/test/fixtures/njt_bus.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NEXTTRIPROWSET>
+  <Trip>
+    <Trip_id>630</Trip_id>
+    <arrival_time>10:39:00</arrival_time>
+    <departure_time>10:39:00</departure_time>
+    <sched_dep_time>5/19/2021 10:37:00 AM</sched_dep_time>
+    <stop_id>43249</stop_id>
+    <stop_sequence>58</stop_sequence>
+    <route>10</route>
+    <header>10 JERSEY CITY JOURNAL SQUARE-Exact Fare</header>
+    <stop_name>JOURNAL SQUARE TRANSPORTATION CENTER</stop_name>
+    <timing_point_id>JONLSQAR</timing_point_id>
+    <stop_lat>40.732048</stop_lat>
+    <stop_lon>-74.062003</stop_lon>
+    <sec_late>60</sec_late>
+  </Trip>
+  <Trip>
+    <Trip_id>28152</Trip_id>
+    <arrival_time>10:37:00</arrival_time>
+    <departure_time>10:37:00</departure_time>
+    <sched_dep_time>5/19/2021 11:00:00 AM</sched_dep_time>
+    <stop_id>43249</stop_id>
+    <stop_sequence>32</stop_sequence>
+    <route>87</route>
+    <header>87 HOBOKEN-PATH VIA JOURNAL SQ-Exact Fare</header>
+    <stop_name>JOURNAL SQUARE TRANSPORTATION CENTER</stop_name>
+    <timing_point_id>HUDSTERM</timing_point_id>
+    <stop_lat>40.732048</stop_lat>
+    <stop_lon>-74.062003</stop_lon>
+    <sec_late>-240</sec_late>
+  </Trip>
+</NEXTTRIPROWSET>

--- a/test/test_njt_bus.py
+++ b/test/test_njt_bus.py
@@ -1,0 +1,41 @@
+import pytest
+
+from gtfs_realtime_translators.factories import FeedMessage
+from gtfs_realtime_translators.translators import NjtBusGtfsRealtimeTranslator
+from gtfs_realtime_translators.bindings import intersection_pb2 as intersection_gtfs_realtime
+
+
+@pytest.fixture
+def njt_bus():
+    with open('test/fixtures/njt_bus.xml') as f:
+        raw = f.read()
+    return raw
+
+
+def test_njt_data(njt_bus):
+    translator = NjtBusGtfsRealtimeTranslator()
+    message = translator(njt_bus)
+
+    entity = message.entity[0]
+    trip_update = entity.trip_update
+    stop_time_update = trip_update.stop_time_update[0]
+
+    assert message.header.gtfs_realtime_version == FeedMessage.VERSION
+    assert entity.id == '1'
+    assert trip_update.trip.route_id == '10'
+    assert trip_update.trip.trip_id == '630'
+
+    assert stop_time_update.stop_id == '43249'
+    assert stop_time_update.arrival.time == 1621435140
+    assert stop_time_update.departure.time == 1621435140
+
+    intersection_trip_update = trip_update.Extensions[
+        intersection_gtfs_realtime.intersection_trip_update]
+    assert intersection_trip_update.headsign == '10 JERSEY CITY JOURNAL SQUARE-Exact Fare'
+    assert intersection_trip_update.agency_timezone == 'America/New_York'
+
+    intersection_stop_time_update = stop_time_update.Extensions[
+        intersection_gtfs_realtime.intersection_stop_time_update]
+    assert intersection_stop_time_update.scheduled_arrival.time == 1621435020
+    assert intersection_stop_time_update.scheduled_departure.time == 1621435020
+    assert intersection_stop_time_update.stop_name == 'JOURNAL SQUARE TRANSPORTATION CENTER'


### PR DESCRIPTION
Added Translator for NJT real time bus feed processing.
Added tests to verify the translator.

Below is truncated sample Arrivals Service Response:
```
{
    "njt-bus:43249": [
        {
            "arrival_time": 1621873800,
            "departure_time": 1621873800,
            "event_id": "ddc10034-0788-4aa1-af04-5e52cecbca47",
            "event_time": 1621873854,
            "headsign": "10 BAYONNE-Exact Fare",
            "id": 9,
            "org_short_key": "njt-bus",
            "route_id": "3",
            "route_color": "000000",
            "route_long_name": "",
            "route_short_name": "117",
            "route_text_color": "000000",
            "schedule_status": "ScheduleStatus.unknown",
            "scheduled_arrival_time": 1621873800,
            "scheduled_departure_time": 1621873800,
            "stop_id": "43249",
            "stop_name": "JOURNAL SQUARE TRANSPORTATION CENTER",
            "trip_id": "696",
            "agency_timezone": "America/New_York",
            "track": "",
            "version": "v1",
            "custom_status": "",
            "terminus_relation": "origin"
        }
    ]
}
```