### PR TITLE
TRAN-5521 : Real-time NJT bus arrivals data in PATH org are showing the wrong route number

### DIFF
--- a/gtfs_realtime_translators/translators/njt_bus.py
+++ b/gtfs_realtime_translators/translators/njt_bus.py
@@ -42,7 +42,7 @@ class NjtBusGtfsRealtimeTranslator:
                 # Intersection Extensions
                 headsign = item_entry['busheader']
                 trip_id = item_entry['gtfs_trip_id']
-                route_id = item_entry['route']
+                route_id = item_entry['gtfs_route_id']
                 if item_entry.get('STOP', None) is not None:
                     stops = item_entry['STOP']
 

--- a/test/test_njt_bus.py
+++ b/test/test_njt_bus.py
@@ -23,7 +23,7 @@ def test_njt_data(njt_bus):
 
     assert message.header.gtfs_realtime_version == FeedMessage.VERSION
     assert entity.id == '1'
-    assert trip_update.trip.route_id == '64J'
+    assert trip_update.trip.route_id == '165'
     assert trip_update.trip.trip_id == '22899'
 
     assert stop_time_update.stop_id == '2916'


### PR DESCRIPTION
Replaced the Translator code to use "`gtfs_route_id`" instead of "`route`" for `route_id` field.