### PR TITLE
TRAN-5926: Modified logic to set arrival and departure times for mbta

### DIFF
--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import json
 
 import pendulum

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -14,47 +14,46 @@ class MbtaGtfsRealtimeTranslator:
         entities = self.__make_trip_updates(predictions)
         return FeedMessage.create(entities=entities)
 
-
     @classmethod
     def __to_unix_time(cls, time):
-      return pendulum.parse(time).in_tz(cls.TIMEZONE).int_timestamp
+        return pendulum.parse(time).in_tz(cls.TIMEZONE).int_timestamp
 
     @classmethod
     def __make_trip_updates(cls, predictions):
-      trip_updates = []
-      for idx, prediction in enumerate(predictions):
-        entity_id = str(idx + 1)
-        relationships = prediction['relationships']
-        attributes = prediction['attributes']
-        stop_id = relationships['stop']['data']['id']
-        route_id = relationships['route']['data']['id']
-        trip_id = relationships['trip']['data']['id']
-        raw_arrival_time = attributes['arrival_time']
-        raw_departure_time = attributes['departure_time']
+        trip_updates = []
+        for idx, prediction in enumerate(predictions):
+            entity_id = str(idx + 1)
+            relationships = prediction['relationships']
+            attributes = prediction['attributes']
+            stop_id = relationships['stop']['data']['id']
+            route_id = relationships['route']['data']['id']
+            trip_id = relationships['trip']['data']['id']
+            raw_arrival_time = attributes['arrival_time']
+            raw_departure_time = attributes['departure_time']
 
-        if cls.should_capture_prediction(raw_arrival_time, raw_departure_time):
-          if raw_arrival_time and raw_departure_time:
-            arrival_time = cls.__to_unix_time(raw_arrival_time)
-            departure_time = cls.__to_unix_time(raw_departure_time)
-          elif raw_arrival_time:
-            arrival_time = cls.__to_unix_time(raw_arrival_time)
-            departure_time = arrival_time
-          elif raw_departure_time:
-            departure_time = cls.__to_unix_time(raw_departure_time)
-            arrival_time = departure_time
-                      
-          trip_update = TripUpdate.create(
-            entity_id=entity_id,
-            route_id=route_id,
-            stop_id=stop_id,
-            trip_id=trip_id,
-            arrival_time=arrival_time,
-            departure_time=departure_time
-          )
-          trip_updates.append(trip_update)
-      
-      return trip_updates
+            if cls.should_capture_prediction(raw_arrival_time, raw_departure_time):
+                if raw_arrival_time and raw_departure_time:
+                    arrival_time = cls.__to_unix_time(raw_arrival_time)
+                    departure_time = cls.__to_unix_time(raw_departure_time)
+                elif raw_arrival_time:
+                    arrival_time = cls.__to_unix_time(raw_arrival_time)
+                    departure_time = arrival_time
+                elif raw_departure_time:
+                    departure_time = cls.__to_unix_time(raw_departure_time)
+                    arrival_time = departure_time
+
+                trip_update = TripUpdate.create(
+                    entity_id=entity_id,
+                    route_id=route_id,
+                    stop_id=stop_id,
+                    trip_id=trip_id,
+                    arrival_time=arrival_time,
+                    departure_time=departure_time
+                )
+                trip_updates.append(trip_update)
+
+        return trip_updates
 
     @staticmethod
     def should_capture_prediction(raw_arrival_time, raw_departure_time):
-      return raw_arrival_time or raw_departure_time
+        return raw_arrival_time or raw_departure_time

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -62,4 +62,5 @@ class MbtaGtfsRealtimeTranslator:
 
     @staticmethod
     def should_capture_prediction(raw_arrival_time, raw_departure_time):
-        return raw_arrival_time or raw_departure_time
+        should_capture = raw_arrival_time or raw_departure_time
+        return should_capture

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -55,5 +55,6 @@ class MbtaGtfsRealtimeTranslator:
       
       return trip_updates
 
+    @staticmethod
     def should_capture_prediction(raw_arrival_time, raw_departure_time):
       return raw_arrival_time or raw_departure_time

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -32,16 +32,8 @@ class MbtaGtfsRealtimeTranslator:
             raw_departure_time = attributes['departure_time']
 
             if cls.should_capture_prediction(raw_arrival_time, raw_departure_time):
-                if raw_arrival_time and raw_departure_time:
-                    arrival_time = cls.__to_unix_time(raw_arrival_time)
-                    departure_time = cls.__to_unix_time(raw_departure_time)
-                elif raw_arrival_time:
-                    arrival_time = cls.__to_unix_time(raw_arrival_time)
-                    departure_time = arrival_time
-                elif raw_departure_time:
-                    departure_time = cls.__to_unix_time(raw_departure_time)
-                    arrival_time = departure_time
-
+                arrival_time, departure_time = cls.set_arrival_and_departure_times(
+                    raw_arrival_time, raw_departure_time)
                 trip_update = TripUpdate.create(
                     entity_id=entity_id,
                     route_id=route_id,
@@ -53,6 +45,20 @@ class MbtaGtfsRealtimeTranslator:
                 trip_updates.append(trip_update)
 
         return trip_updates
+
+    @staticmethod
+    def set_arrival_and_departure_times(raw_arrival_time, raw_departure_time):
+        if raw_arrival_time:
+            arrival_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
+                raw_arrival_time)
+        if raw_departure_time:
+            departure_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
+                raw_departure_time)
+        if not raw_arrival_time:
+            arrival_time = departure_time
+        if not raw_departure_time:
+            departure_time = arrival_time
+        return arrival_time, departure_time
 
     @staticmethod
     def should_capture_prediction(raw_arrival_time, raw_departure_time):

--- a/test/fixtures/mbta_bus.json
+++ b/test/fixtures/mbta_bus.json
@@ -37,8 +37,8 @@
       },
       {
           "attributes": {
-              "arrival_time": null,
-              "departure_time": null,
+              "arrival_time": "2021-09-27T17:38:53-04:00",
+              "departure_time": "2021-09-27T17:38:53-04:00",
               "direction_id": 0,
               "schedule_relationship": null,
               "status": null,
@@ -75,7 +75,7 @@
       },
       {
           "attributes": {
-              "arrival_time": "2021-09-27T17:38:53-04:00",
+              "arrival_time": null,
               "departure_time": "2021-09-27T17:38:53-04:00",
               "direction_id": 0,
               "schedule_relationship": null,
@@ -114,7 +114,7 @@
       {
           "attributes": {
               "arrival_time": "2021-09-27T17:51:18-04:00",
-              "departure_time": "2021-09-27T17:51:18-04:00",
+              "departure_time": null,
               "direction_id": 0,
               "schedule_relationship": null,
               "status": null,

--- a/test/test_mbta.py
+++ b/test/test_mbta.py
@@ -35,11 +35,28 @@ def test_mbta_subway_realtime_arrival(mbta_subway):
     assert stop_time_update.arrival.time == 1632770790
     assert stop_time_update.departure.time == 1632770846
 
-def test_mbta_bus_realtime_arrival(mbta_bus):
+def test_mbta_bus_realtime_arrival_departure(mbta_bus):
     translator = MbtaGtfsRealtimeTranslator()
     message = translator(mbta_bus)
 
     entity = message.entity[0]
+    trip_update = entity.trip_update
+    stop_time_update = trip_update.stop_time_update[0]
+
+    assert message.header.gtfs_realtime_version == FeedMessage.VERSION
+
+    assert entity.id == '2'
+    assert entity.trip_update.trip.route_id == '66'
+    assert entity.trip_update.trip.trip_id == '49181421'
+    assert stop_time_update.stop_id == '1357'
+    assert stop_time_update.arrival.time == 1632778733
+    assert stop_time_update.departure.time == 1632778733
+
+def test_mbta_bus_realtime_no_arrival_departure(mbta_bus):
+    translator = MbtaGtfsRealtimeTranslator()
+    message = translator(mbta_bus)
+
+    entity = message.entity[1]
     trip_update = entity.trip_update
     stop_time_update = trip_update.stop_time_update[0]
 
@@ -52,3 +69,19 @@ def test_mbta_bus_realtime_arrival(mbta_bus):
     assert stop_time_update.arrival.time == 1632778733
     assert stop_time_update.departure.time == 1632778733
 
+def test_mbta_bus_realtime_arrival_no_departure(mbta_bus):
+    translator = MbtaGtfsRealtimeTranslator()
+    message = translator(mbta_bus)
+
+    entity = message.entity[2]
+    trip_update = entity.trip_update
+    stop_time_update = trip_update.stop_time_update[0]
+
+    assert message.header.gtfs_realtime_version == FeedMessage.VERSION
+
+    assert entity.id == '4'
+    assert entity.trip_update.trip.route_id == '66'
+    assert entity.trip_update.trip.trip_id == '49181350'
+    assert stop_time_update.stop_id == '1357'
+    assert stop_time_update.arrival.time == 1632779478
+    assert stop_time_update.departure.time == 1632779478


### PR DESCRIPTION
After this change, 
If either arrival or departure time is present when translating realtime arrivals, then both will be set to the present value.
There is no change to other cases of arrival and departure time translating.