### PR TITLE
TRAN-5742: Renaming LA, VTA, and PATH. Restoring Old PATH Translator.

### DIFF
--- a/gtfs_realtime_translators/registry/registry.py
+++ b/gtfs_realtime_translators/registry/registry.py
@@ -15,7 +15,6 @@ class TranslatorRegistry:
     TRANSLATORS = {
         'la-metro-old': LaMetroGtfsRealtimeTranslator,
         'septa-regional-rail': SeptaRegionalRailTranslator,
-        'septa': SwiftlyGtfsRealtimeTranslator,
         'cta-subway': CtaSubwayGtfsRealtimeTranslator,
         'cta-bus': CtaBusGtfsRealtimeTranslator,
         'mta-subway': MtaSubwayGtfsRealtimeTranslator,

--- a/gtfs_realtime_translators/registry/registry.py
+++ b/gtfs_realtime_translators/registry/registry.py
@@ -12,7 +12,7 @@ class TranslatorKeyWarning(Warning):
 
 class TranslatorRegistry:
     TRANSLATORS = {
-        'la-metro': LaMetroGtfsRealtimeTranslator,
+        'la-metro-old': LaMetroGtfsRealtimeTranslator,
         'septa-regional-rail': SeptaRegionalRailTranslator,
         'septa': SwiftlyGtfsRealtimeTranslator,
         'cta-subway': CtaSubwayGtfsRealtimeTranslator,
@@ -20,8 +20,8 @@ class TranslatorRegistry:
         'mta-subway': MtaSubwayGtfsRealtimeTranslator,
         'njt-rail': NjtRailGtfsRealtimeTranslator,
         'njt-bus': NjtBusGtfsRealtimeTranslator,
-        'path': PathGtfsRealtimeTranslator,
-        'vta': SwiftlyGtfsRealtimeTranslator,
+        'path-old': PathGtfsRealtimeTranslator,
+        'swiftly': SwiftlyGtfsRealtimeTranslator,
         'wcdot-bus': WcdotGtfsRealTimeTranslator,
         'mbta': MbtaGtfsRealtimeTranslator,
     }

--- a/gtfs_realtime_translators/registry/registry.py
+++ b/gtfs_realtime_translators/registry/registry.py
@@ -3,7 +3,8 @@ import warnings
 from gtfs_realtime_translators.translators import LaMetroGtfsRealtimeTranslator, \
     SeptaRegionalRailTranslator, MtaSubwayGtfsRealtimeTranslator, NjtRailGtfsRealtimeTranslator, \
     CtaSubwayGtfsRealtimeTranslator, CtaBusGtfsRealtimeTranslator, PathGtfsRealtimeTranslator, \
-    SwiftlyGtfsRealtimeTranslator, WcdotGtfsRealTimeTranslator, NjtBusGtfsRealtimeTranslator, MbtaGtfsRealtimeTranslator
+    PathNewGtfsRealtimeTranslator, SwiftlyGtfsRealtimeTranslator, WcdotGtfsRealTimeTranslator, \
+    NjtBusGtfsRealtimeTranslator, MbtaGtfsRealtimeTranslator
 
 
 class TranslatorKeyWarning(Warning):
@@ -21,6 +22,7 @@ class TranslatorRegistry:
         'njt-rail': NjtRailGtfsRealtimeTranslator,
         'njt-bus': NjtBusGtfsRealtimeTranslator,
         'path-old': PathGtfsRealtimeTranslator,
+        'path-new': PathNewGtfsRealtimeTranslator,
         'swiftly': SwiftlyGtfsRealtimeTranslator,
         'wcdot-bus': WcdotGtfsRealTimeTranslator,
         'mbta': MbtaGtfsRealtimeTranslator,

--- a/gtfs_realtime_translators/translators/__init__.py
+++ b/gtfs_realtime_translators/translators/__init__.py
@@ -6,6 +6,7 @@ from .njt_bus import NjtBusGtfsRealtimeTranslator
 from .cta_subway import CtaSubwayGtfsRealtimeTranslator
 from .cta_bus import CtaBusGtfsRealtimeTranslator
 from .path_rail import PathGtfsRealtimeTranslator
+from .path_new import PathNewGtfsRealtimeTranslator
 from .swiftly import SwiftlyGtfsRealtimeTranslator
 from .wcdot_bus import WcdotGtfsRealTimeTranslator
 from .mbta import MbtaGtfsRealtimeTranslator

--- a/gtfs_realtime_translators/translators/path_new.py
+++ b/gtfs_realtime_translators/translators/path_new.py
@@ -1,0 +1,215 @@
+import json
+import pendulum
+
+from gtfs_realtime_translators.factories import FeedMessage, TripUpdate
+
+class PathNewGtfsRealtimeTranslator:
+    TIMEZONE = 'America/New_York'
+
+    SERVICE_LOOKUP = {
+        '5': {
+             'JSQ':'Journal Square Via Hoboken',
+             '33S':'33rd St Via Hoboken',
+             'HOB': 'Hoboken',
+             'route_id':'1024'
+        },
+        '4':{
+            'WTC': 'World Trade Center',
+            'HOB': 'Hoboken',
+            'route_id':'860'
+        },
+        '3':{
+            '33S': '33rd Street',
+            'HOB': 'Hoboken',
+            'route_id':'859'
+        },
+        '2':{
+            'JSQ': 'Journal Square',
+            '33S': '33rd Street',
+            'route_id':'861'
+        },
+        '1':{
+            'WTC': 'World Trade Center',
+            'NWK': 'Newark',
+            'route_id': '862'
+        }
+    }
+    STOP_ID_LOOKUP = {
+        'GRV':{
+            "stop_name":'Grove Street',
+            "tracks":{
+                "Tunnel H": '781726',
+                "Tunnel G": '781727',
+            }
+        },
+        'WTC':{
+            "stop_name":'World Trade Center',
+            "tracks":{
+                "Track 1": '781763T1',
+                "Track 2": '781763T2',
+                "Track 3": '781763T3',
+                "Track 4": '794724T4',
+                "Track 5": '794724T5',
+            }
+        },
+        'NWK':{
+            "stop_name":'Newark',
+            "tracks":{
+                "Track G":'781719',
+                "Track H": '781718'
+            }
+        },
+        'HAR':{
+            "stop_name":'Harrison',
+            "tracks":{
+                "Track H": '781720',
+                "Track G": '781721',
+            }
+        },
+        'EXP':{
+            "stop_name":'Exchange Place',
+            "tracks":{
+                "Tunnel E": '781731',
+                "Tunnel F":'781730',
+            }
+        },
+        "NEW":{
+            "stop_name":'Newport',
+            "tracks":{
+                "Tunnel E": '781728',
+                "Tunnel F":'781729',
+            }
+        },
+        "CHR":{
+            "stop_name":'Christopher Street',
+            "tracks":{
+                "Tunnel B":'781732',
+                "Tunnel A":'781733'
+            }
+        },
+        "09S":{
+            "stop_name":'9th Street',
+            "tracks":{
+                "Tunnel B":'781734',
+                "Tunnel A":'781735',
+            }
+        },
+        "14S":{
+            "stop_name":'14th Stret',
+            "tracks":{  
+                "Tunnel B": '781736',
+                "Tunnel A": '781737',
+            }
+
+        },
+        "23S":{
+            "stop_name":'23rd Street',
+            "tracks":{
+                "Tunnel B": '781738',
+                "Tunnel A": '781739',
+            }
+        },
+        "JSQ":{
+            "stop_name":'Christopher Street',
+            "tracks":{
+                "Track 1":'781722',
+                "Track 2":'781723',
+                "Track 3":'781724',
+                "Track 4":'781725',
+            }
+        },
+        "33S":{
+            "stop_name":'33rd Street',
+            "tracks":{
+                "Track 1":'781741T1',
+                "Track 2":'781740',
+                "Track 3":'781741T3',
+            }
+        },
+        "HOB":{
+            "stop_name":'Hoboken',
+            "tracks":{
+                "Track 1":'781717',
+                "Track 2":'781715',
+                "Track 3":'781716'
+            } 
+        }
+    }
+
+    """
+       Since PATH GTFS data have stops that are, in most cases, unique to a route, direction, service date, and/or 
+       destination, a mapping is created to ensure we return the appropriate stop_id/headsign/route information for a stop and track arrival updates.
+       
+       Keys are based off the "serviceID" field while also using a second lookup to determine the stop_id based on the track for a particular station
+    """
+
+    def __call__(self, data):
+        json_data = json.loads(data)
+        entities = self.__make_trip_updates(json_data)
+        return FeedMessage.create(entities=entities)
+
+    @classmethod
+    def __to_unix_time(cls, time):
+        datetime = int(pendulum.from_format(time, 'HH:mm').in_tz(cls.TIMEZONE).timestamp())
+        return datetime
+
+    @classmethod
+    def __route_lookup(cls,service_id, station_shortkey, track_id, destination):
+        service_mapping = cls.SERVICE_LOOKUP.get(str(service_id))
+        station_mapping = cls.STOP_ID_LOOKUP.get(station_shortkey)
+        route_id = service_mapping.get('route_id')
+        headsign = service_mapping.get(destination)
+        stop_id = station_mapping.get("tracks").get(track_id)
+        stop_name = station_mapping.get("stop_name")
+        return {
+           'route_id': route_id,
+            'stop_id': stop_id,
+            'headsign': headsign,
+            'stop_name': stop_name
+        }
+
+    @classmethod 
+    def __should_skip_update(cls,route_data):
+        should_skip = False
+        for key, value in route_data.items():
+            if value is None:
+                should_skip = True
+                break
+        return should_skip    
+
+    @classmethod
+    def __make_trip_updates(cls, data):
+        trip_updates = []
+        stations = data['stations']
+        for station in stations:
+            station_shortkey = station['abbrv']
+            tracks = station.get('tracks')
+            if station_shortkey == 'systemwide':
+                continue
+            for track in tracks:
+                track_id = track.get('trackId')
+                trains = track.get('trains',{})
+                for idx,train in enumerate(trains):
+                    if not train.get('trainId'):
+                        continue
+                    train_info = train.get('trainId').split('_')
+                    service_id = train.get('service')
+                    destination = train.get('destination')
+                    arrival_time = train.get('depArrTime')
+                    scheduled_arrival_time = cls.__to_unix_time(train_info[0])
+                    arrival_data = cls.__route_lookup(service_id,station_shortkey,track_id, destination)
+                    if cls.__should_skip_update(arrival_data):
+                        continue
+                    trip_update = TripUpdate.create(entity_id=train.get('trainId').strip(),
+                                                    departure_time=arrival_time,
+                                                    arrival_time=arrival_time,
+                                                    scheduled_arrival_time=scheduled_arrival_time,
+                                                    scheduled_departure_time = scheduled_arrival_time,
+                                                    track=track_id,
+                                                    route_id=arrival_data.get('route_id'),
+                                                    stop_id=arrival_data.get('stop_id'),
+                                                    headsign=arrival_data.get('headsign'),
+                                                    stop_name=arrival_data.get('stop_name'))
+                    trip_updates.append(trip_update)
+
+        return trip_updates

--- a/test/fixtures/path_new.json
+++ b/test/fixtures/path_new.json
@@ -1,0 +1,1122 @@
+{
+  "messageTimestamp": "2021-11-01T19:51:31.485103",
+  "stations": [
+      {
+          "abbrv": "systemwide",
+          "signinfo": {
+              "location": "stationwide",
+              "overrideText": "",
+              "overrideTextTimestamp": 1635810691,
+              "scrollingText": "",
+              "scrollingTextTimestamp": 1635810691
+          },
+          "tracks": []
+      },
+      {
+          "abbrv": "NWK",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "NWK_Platform_H",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "NWK_Platform_C",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635769891,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "NWK_Platform_B",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635769891,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Track H",
+                  "trains": [
+                      {
+                          "atsTime": 1635796266,
+                          "depArrTime": 1635796500,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "",
+                          "trainId": "15:55_NWK/WTC "
+                      },
+                      {
+                          "atsTime": 1635796266,
+                          "depArrTime": 1635796740,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "",
+                          "trainId": "15:59_NWK/WTC "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track G",
+                  "trains": [
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "HAR",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "HAR_Track_G",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635805367,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "HAR_Track_H",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635769965,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Track H",
+                  "trains": [
+                      {
+                          "atsTime": 1635796291,
+                          "depArrTime": 1635796334,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "784T_NW_01",
+                          "trainId": "15:50_NWK/WTC "
+                      },
+                      {
+                          "atsTime": 1635796104,
+                          "depArrTime": 1635796589,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "",
+                          "trainId": "15:55_NWK/WTC "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track G",
+                  "trains": [
+                      {
+                          "atsTime": 1635796264,
+                          "depArrTime": 1635796297,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "781T_HR_03",
+                          "trainId": "15:32_WTC/NWK "
+                      },
+                      {
+                          "atsTime": 1635796288,
+                          "depArrTime": 1635796820,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "57T_JS_01",
+                          "trainId": "15:42_WTC/NWK "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "JSQ",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "JSQ_Fare_Zone",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "JSQ_EastBound",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635510222,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "JSQ_WestBound",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Track 1",
+                  "trains": [
+                      {
+                          "atsTime": 1635796268,
+                          "depArrTime": 1635796304,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "728T_JS_04",
+                          "trainId": "15:40_NWK/WTC "
+                      },
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796654,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "758T_HR_02",
+                          "trainId": "15:46_NWK/WTC "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 2",
+                  "trains": [
+                      {
+                          "atsTime": 1635796226,
+                          "depArrTime": 1635796440,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "726T_JS_04",
+                          "trainId": "15:54_JSQ/33S "
+                      },
+                      {
+                          "atsTime": 1635796188,
+                          "depArrTime": 1635796740,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "",
+                          "trainId": "15:59_JSQ/33S "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 3",
+                  "trains": [
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 4",
+                  "trains": [
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796334,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "57T_JS_01",
+                          "trainId": "15:42_WTC/NWK "
+                      },
+                      {
+                          "atsTime": 1635796047,
+                          "depArrTime": 1635796936,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "283T_WT_02",
+                          "trainId": "15:52_WTC/NWK "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "GRV",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "GRV_Station",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel H",
+                  "trains": [
+                      {
+                          "atsTime": 1635796289,
+                          "depArrTime": 1635796390,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "371T_JS_03",
+                          "trainId": "15:49_JSQ/33S "
+                      },
+                      {
+                          "atsTime": 1635796276,
+                          "depArrTime": 1635796515,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "728T_JS_04",
+                          "trainId": "15:40_NWK/WTC "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel G",
+                  "trains": [
+                      {
+                          "atsTime": 1635796286,
+                          "depArrTime": 1635796567,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "501T_HB_01",
+                          "trainId": "15:37_33S/JSQ "
+                      },
+                      {
+                          "atsTime": 1635796122,
+                          "depArrTime": 1635796703,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "283T_WT_02",
+                          "trainId": "15:52_WTC/NWK "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "EXP",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "EXP_Fare_Zone",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "EXP_Track_E",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635757357,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "EXP_Track_F",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635760795,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel F",
+                  "trains": [
+                      {
+                          "atsTime": 1635796283,
+                          "depArrTime": 1635796349,
+                          "destination": "WTC",
+                          "service": 4,
+                          "tbLocation": "31T_GJ_01",
+                          "trainId": "15:45_HOB/WTC "
+                      },
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796434,
+                          "destination": "WTC",
+                          "service": 1,
+                          "tbLocation": "391T_GJ_01",
+                          "trainId": "15:36_NWK/WTC "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel E",
+                  "trains": [
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796516,
+                          "destination": "HOB",
+                          "service": 4,
+                          "tbLocation": "277T_WT_02",
+                          "trainId": "15:51_WTC/HOB "
+                      },
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796601,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "283T_WT_02",
+                          "trainId": "15:52_WTC/NWK "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "WTC",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "WTC_Fare_Zone",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "WTC_Platform_A",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "WTC_Platform_B",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "WTC_Platform_C",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "WTC_Platform_D",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Track 1",
+                  "trains": [
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 2",
+                  "trains": [
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796289,
+                          "destination": "HOB",
+                          "service": 4,
+                          "tbLocation": "277T_WT_02",
+                          "trainId": "15:51_WTC/HOB "
+                      },
+                      {
+                          "atsTime": 1635795578,
+                          "depArrTime": 1635796980,
+                          "destination": "HOB",
+                          "service": 4,
+                          "tbLocation": "",
+                          "trainId": "16:03_WTC/HOB "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 3",
+                  "trains": [
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 4",
+                  "trains": [
+                      {
+                          "atsTime": 1635796102,
+                          "depArrTime": 1635796620,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "281T_WT_02",
+                          "trainId": "15:57_WTC/NWK "
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 5",
+                  "trains": [
+                      {
+                          "atsTime": 1635796047,
+                          "depArrTime": 1635796320,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "283T_WT_02",
+                          "trainId": "15:52_WTC/NWK "
+                      },
+                      {
+                          "atsTime": 1635796102,
+                          "depArrTime": 1635796920,
+                          "destination": "NWK",
+                          "service": 1,
+                          "tbLocation": "",
+                          "trainId": "16:02_WTC/NWK "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "NEW",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "NEW_Fare",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1634943649,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "NEW_Side_Platform",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511110,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "NEW_Central_Platform",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635462070,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel E",
+                  "trains": [
+                      {
+                          "atsTime": 1635796289,
+                          "depArrTime": 1635796582,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "371T_JS_03",
+                          "trainId": "15:49_JSQ/33S "
+                      },
+                      {
+                          "atsTime": 1635796290,
+                          "depArrTime": 1635796682,
+                          "destination": "HOB",
+                          "service": 4,
+                          "tbLocation": "277T_WT_02",
+                          "trainId": "15:51_WTC/HOB "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel F",
+                  "trains": [
+                      {
+                          "atsTime": 1635796286,
+                          "depArrTime": 1635796377,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "501T_HB_01",
+                          "trainId": "15:37_33S/JSQ "
+                      },
+                      {
+                          "atsTime": 1635796287,
+                          "depArrTime": 1635796794,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "158T_33_01",
+                          "trainId": "15:47_33S/JSQ "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "HOB",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "HOB_Fare_Zone",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1634994934,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "HOB_Platform_1",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635163241,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "HOB_Platform_2",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1634994934,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "HOB_Platform_3",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1634215916,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Track 1",
+                  "trains": [
+                      {
+                          "atsTime": 1635796113,
+                          "depArrTime": 1635796320,
+                          "destination": "33S",
+                          "service": 3,
+                          "tbLocation": "100T_HB_04",
+                          "trainId": "15:52_HOB/33S "
+                      },
+                      {
+                          "atsTime": 1635795769,
+                          "depArrTime": 1635796920,
+                          "destination": "33S",
+                          "service": 3,
+                          "tbLocation": "",
+                          "trainId": "16:02_HOB/33S "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 2",
+                  "trains": [
+                      {
+                          "atsTime": 1635796202,
+                          "depArrTime": 1635796620,
+                          "destination": "WTC",
+                          "service": 4,
+                          "tbLocation": "96T_HB_01",
+                          "trainId": "15:57_HOB/WTC "
+                      },
+                      {
+                          "atsTime": 1635795993,
+                          "depArrTime": 1635797340,
+                          "destination": "WTC",
+                          "service": 4,
+                          "tbLocation": "",
+                          "trainId": "16:09_HOB/WTC "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 3",
+                  "trains": [
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "CHR",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "CHR_Station",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511738,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel B",
+                  "trains": [
+                      {
+                          "atsTime": 1635796289,
+                          "depArrTime": 1635796462,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "121T_HB_03",
+                          "trainId": "15:39_JSQ/33S "
+                      },
+                      {
+                          "atsTime": 1635796253,
+                          "depArrTime": 1635796783,
+                          "destination": "33S",
+                          "service": 3,
+                          "tbLocation": "100T_HB_04",
+                          "trainId": "15:52_HOB/33S "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel A",
+                  "trains": [
+                      {
+                          "atsTime": 1635796287,
+                          "depArrTime": 1635796377,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "158T_33_01",
+                          "trainId": "15:47_33S/JSQ "
+                      },
+                      {
+                          "atsTime": 1635796108,
+                          "depArrTime": 1635796675,
+                          "destination": "HOB",
+                          "service": 3,
+                          "tbLocation": "195T_33_01",
+                          "trainId": "15:52_33S/HOB "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "09S",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "09S_Station",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511738,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel B",
+                  "trains": [
+                      {
+                          "atsTime": 1635796288,
+                          "depArrTime": 1635796322,
+                          "destination": "33S",
+                          "service": 3,
+                          "tbLocation": "147AT_33_02",
+                          "trainId": "15:42_HOB/33S "
+                      },
+                      {
+                          "atsTime": 1635796289,
+                          "depArrTime": 1635796559,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "121T_HB_03",
+                          "trainId": "15:39_JSQ/33S "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel A",
+                  "trains": [
+                      {
+                          "atsTime": 1635796287,
+                          "depArrTime": 1635796295,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "158T_33_01",
+                          "trainId": "15:47_33S/JSQ "
+                      },
+                      {
+                          "atsTime": 1635796107,
+                          "depArrTime": 1635796593,
+                          "destination": "HOB",
+                          "service": 3,
+                          "tbLocation": "195T_33_01",
+                          "trainId": "15:52_33S/HOB "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "14S",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "14S_Track_B",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511738,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "14S_Track_A",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511738,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel B",
+                  "trains": [
+                      {
+                          "atsTime": 1635796288,
+                          "depArrTime": 1635796417,
+                          "destination": "33S",
+                          "service": 3,
+                          "tbLocation": "147AT_33_02",
+                          "trainId": "15:42_HOB/33S "
+                      },
+                      {
+                          "atsTime": 1635796289,
+                          "depArrTime": 1635796654,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "121T_HB_03",
+                          "trainId": "15:39_JSQ/33S "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel A",
+                  "trains": [
+                      {
+                          "atsTime": 1635796224,
+                          "depArrTime": 1635796497,
+                          "destination": "HOB",
+                          "service": 3,
+                          "tbLocation": "195T_33_01",
+                          "trainId": "15:52_33S/HOB "
+                      },
+                      {
+                          "atsTime": 1635796238,
+                          "depArrTime": 1635796797,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "187T_33_04",
+                          "trainId": "15:57_33S/JSQ "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "23S",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "23S_Track_B",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511738,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "23S_Track_A",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635511738,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Tunnel B",
+                  "trains": [
+                      {
+                          "atsTime": 1635796288,
+                          "depArrTime": 1635796503,
+                          "destination": "33S",
+                          "service": 3,
+                          "tbLocation": "147AT_33_02",
+                          "trainId": "15:42_HOB/33S "
+                      },
+                      {
+                          "atsTime": 1635796289,
+                          "depArrTime": 1635796740,
+                          "destination": "33S",
+                          "service": 2,
+                          "tbLocation": "121T_HB_03",
+                          "trainId": "15:39_JSQ/33S "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Tunnel A",
+                  "trains": [
+                      {
+                          "atsTime": 1635796137,
+                          "depArrTime": 1635796409,
+                          "destination": "HOB",
+                          "service": 3,
+                          "tbLocation": "195T_33_01",
+                          "trainId": "15:52_33S/HOB "
+                      },
+                      {
+                          "atsTime": 1635796238,
+                          "depArrTime": 1635796709,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "187T_33_04",
+                          "trainId": "15:57_33S/JSQ "
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "abbrv": "33S",
+          "signinfo": [
+              {
+                  "location": "stationwide",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635810691,
+                  "scrollingText": "",
+                  "scrollingTextTimestamp": 1635810691
+              },
+              {
+                  "location": "33S_Fare_Zone",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1633940464,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "33S_Platform_2",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1633964032,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              },
+              {
+                  "location": "33S_Platform_3",
+                  "overrideText": "",
+                  "overrideTextTimestamp": 1635425311,
+                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
+                  "scrollingTextTimestamp": 1635785820
+              }
+          ],
+          "tracks": [
+              {
+                  "trackId": "Track 1",
+                  "trains": [
+                      {
+                          "atsTime": 1635796238,
+                          "depArrTime": 1635796620,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "187T_33_04",
+                          "trainId": "15:57_33S/JSQ "
+                      },
+                      {
+                          "atsTime": 1635796029,
+                          "depArrTime": 1635797220,
+                          "destination": "JSQ",
+                          "service": 2,
+                          "tbLocation": "",
+                          "trainId": "16:07_33S/JSQ "
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 2",
+                  "trains": [
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      },
+                      {
+                          "atsTime": "",
+                          "depArrTime": "",
+                          "destination": "",
+                          "service": "",
+                          "tbLocation": "",
+                          "trainId": ""
+                      }
+                  ]
+              },
+              {
+                  "trackId": "Track 3",
+                  "trains": [
+                      {
+                          "atsTime": 1635796107,
+                          "depArrTime": 1635796320,
+                          "destination": "HOB",
+                          "service": 3,
+                          "tbLocation": "195T_33_01",
+                          "trainId": "15:52_33S/HOB "
+                      },
+                      {
+                          "atsTime": 1635795737,
+                          "depArrTime": 1635796920,
+                          "destination": "HOB",
+                          "service": 3,
+                          "tbLocation": "",
+                          "trainId": "16:02_33S/HOB "
+                      }
+                  ]
+              }
+          ]
+      }
+  ]
+}

--- a/test/fixtures/path_rail.json
+++ b/test/fixtures/path_rail.json
@@ -1,1122 +1,152 @@
 {
-  "messageTimestamp": "2021-11-01T19:51:31.485103",
-  "stations": [
-      {
-          "abbrv": "systemwide",
-          "signinfo": {
-              "location": "stationwide",
-              "overrideText": "",
-              "overrideTextTimestamp": 1635810691,
-              "scrollingText": "",
-              "scrollingTextTimestamp": 1635810691
-          },
-          "tracks": []
-      },
-      {
-          "abbrv": "NWK",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "NWK_Platform_H",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "NWK_Platform_C",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635769891,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "NWK_Platform_B",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635769891,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Track H",
-                  "trains": [
-                      {
-                          "atsTime": 1635796266,
-                          "depArrTime": 1635796500,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "",
-                          "trainId": "15:55_NWK/WTC "
-                      },
-                      {
-                          "atsTime": 1635796266,
-                          "depArrTime": 1635796740,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "",
-                          "trainId": "15:59_NWK/WTC "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track G",
-                  "trains": [
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "HAR",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "HAR_Track_G",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635805367,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "HAR_Track_H",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635769965,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Track H",
-                  "trains": [
-                      {
-                          "atsTime": 1635796291,
-                          "depArrTime": 1635796334,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "784T_NW_01",
-                          "trainId": "15:50_NWK/WTC "
-                      },
-                      {
-                          "atsTime": 1635796104,
-                          "depArrTime": 1635796589,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "",
-                          "trainId": "15:55_NWK/WTC "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track G",
-                  "trains": [
-                      {
-                          "atsTime": 1635796264,
-                          "depArrTime": 1635796297,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "781T_HR_03",
-                          "trainId": "15:32_WTC/NWK "
-                      },
-                      {
-                          "atsTime": 1635796288,
-                          "depArrTime": 1635796820,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "57T_JS_01",
-                          "trainId": "15:42_WTC/NWK "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "JSQ",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "JSQ_Fare_Zone",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "JSQ_EastBound",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635510222,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "JSQ_WestBound",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Track 1",
-                  "trains": [
-                      {
-                          "atsTime": 1635796268,
-                          "depArrTime": 1635796304,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "728T_JS_04",
-                          "trainId": "15:40_NWK/WTC "
-                      },
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796654,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "758T_HR_02",
-                          "trainId": "15:46_NWK/WTC "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 2",
-                  "trains": [
-                      {
-                          "atsTime": 1635796226,
-                          "depArrTime": 1635796440,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "726T_JS_04",
-                          "trainId": "15:54_JSQ/33S "
-                      },
-                      {
-                          "atsTime": 1635796188,
-                          "depArrTime": 1635796740,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "",
-                          "trainId": "15:59_JSQ/33S "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 3",
-                  "trains": [
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 4",
-                  "trains": [
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796334,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "57T_JS_01",
-                          "trainId": "15:42_WTC/NWK "
-                      },
-                      {
-                          "atsTime": 1635796047,
-                          "depArrTime": 1635796936,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "283T_WT_02",
-                          "trainId": "15:52_WTC/NWK "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "GRV",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "GRV_Station",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel H",
-                  "trains": [
-                      {
-                          "atsTime": 1635796289,
-                          "depArrTime": 1635796390,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "371T_JS_03",
-                          "trainId": "15:49_JSQ/33S "
-                      },
-                      {
-                          "atsTime": 1635796276,
-                          "depArrTime": 1635796515,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "728T_JS_04",
-                          "trainId": "15:40_NWK/WTC "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel G",
-                  "trains": [
-                      {
-                          "atsTime": 1635796286,
-                          "depArrTime": 1635796567,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "501T_HB_01",
-                          "trainId": "15:37_33S/JSQ "
-                      },
-                      {
-                          "atsTime": 1635796122,
-                          "depArrTime": 1635796703,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "283T_WT_02",
-                          "trainId": "15:52_WTC/NWK "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "EXP",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "EXP_Fare_Zone",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "EXP_Track_E",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635757357,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "EXP_Track_F",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635760795,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel F",
-                  "trains": [
-                      {
-                          "atsTime": 1635796283,
-                          "depArrTime": 1635796349,
-                          "destination": "WTC",
-                          "service": 4,
-                          "tbLocation": "31T_GJ_01",
-                          "trainId": "15:45_HOB/WTC "
-                      },
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796434,
-                          "destination": "WTC",
-                          "service": 1,
-                          "tbLocation": "391T_GJ_01",
-                          "trainId": "15:36_NWK/WTC "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel E",
-                  "trains": [
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796516,
-                          "destination": "HOB",
-                          "service": 4,
-                          "tbLocation": "277T_WT_02",
-                          "trainId": "15:51_WTC/HOB "
-                      },
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796601,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "283T_WT_02",
-                          "trainId": "15:52_WTC/NWK "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "WTC",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "WTC_Fare_Zone",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "WTC_Platform_A",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "WTC_Platform_B",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "WTC_Platform_C",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "WTC_Platform_D",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Track 1",
-                  "trains": [
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 2",
-                  "trains": [
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796289,
-                          "destination": "HOB",
-                          "service": 4,
-                          "tbLocation": "277T_WT_02",
-                          "trainId": "15:51_WTC/HOB "
-                      },
-                      {
-                          "atsTime": 1635795578,
-                          "depArrTime": 1635796980,
-                          "destination": "HOB",
-                          "service": 4,
-                          "tbLocation": "",
-                          "trainId": "16:03_WTC/HOB "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 3",
-                  "trains": [
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 4",
-                  "trains": [
-                      {
-                          "atsTime": 1635796102,
-                          "depArrTime": 1635796620,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "281T_WT_02",
-                          "trainId": "15:57_WTC/NWK "
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 5",
-                  "trains": [
-                      {
-                          "atsTime": 1635796047,
-                          "depArrTime": 1635796320,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "283T_WT_02",
-                          "trainId": "15:52_WTC/NWK "
-                      },
-                      {
-                          "atsTime": 1635796102,
-                          "depArrTime": 1635796920,
-                          "destination": "NWK",
-                          "service": 1,
-                          "tbLocation": "",
-                          "trainId": "16:02_WTC/NWK "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "NEW",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "NEW_Fare",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1634943649,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "NEW_Side_Platform",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511110,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "NEW_Central_Platform",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635462070,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel E",
-                  "trains": [
-                      {
-                          "atsTime": 1635796289,
-                          "depArrTime": 1635796582,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "371T_JS_03",
-                          "trainId": "15:49_JSQ/33S "
-                      },
-                      {
-                          "atsTime": 1635796290,
-                          "depArrTime": 1635796682,
-                          "destination": "HOB",
-                          "service": 4,
-                          "tbLocation": "277T_WT_02",
-                          "trainId": "15:51_WTC/HOB "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel F",
-                  "trains": [
-                      {
-                          "atsTime": 1635796286,
-                          "depArrTime": 1635796377,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "501T_HB_01",
-                          "trainId": "15:37_33S/JSQ "
-                      },
-                      {
-                          "atsTime": 1635796287,
-                          "depArrTime": 1635796794,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "158T_33_01",
-                          "trainId": "15:47_33S/JSQ "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "HOB",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "HOB_Fare_Zone",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1634994934,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "HOB_Platform_1",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635163241,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "HOB_Platform_2",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1634994934,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "HOB_Platform_3",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1634215916,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Track 1",
-                  "trains": [
-                      {
-                          "atsTime": 1635796113,
-                          "depArrTime": 1635796320,
-                          "destination": "33S",
-                          "service": 3,
-                          "tbLocation": "100T_HB_04",
-                          "trainId": "15:52_HOB/33S "
-                      },
-                      {
-                          "atsTime": 1635795769,
-                          "depArrTime": 1635796920,
-                          "destination": "33S",
-                          "service": 3,
-                          "tbLocation": "",
-                          "trainId": "16:02_HOB/33S "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 2",
-                  "trains": [
-                      {
-                          "atsTime": 1635796202,
-                          "depArrTime": 1635796620,
-                          "destination": "WTC",
-                          "service": 4,
-                          "tbLocation": "96T_HB_01",
-                          "trainId": "15:57_HOB/WTC "
-                      },
-                      {
-                          "atsTime": 1635795993,
-                          "depArrTime": 1635797340,
-                          "destination": "WTC",
-                          "service": 4,
-                          "tbLocation": "",
-                          "trainId": "16:09_HOB/WTC "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 3",
-                  "trains": [
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "CHR",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "CHR_Station",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511738,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel B",
-                  "trains": [
-                      {
-                          "atsTime": 1635796289,
-                          "depArrTime": 1635796462,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "121T_HB_03",
-                          "trainId": "15:39_JSQ/33S "
-                      },
-                      {
-                          "atsTime": 1635796253,
-                          "depArrTime": 1635796783,
-                          "destination": "33S",
-                          "service": 3,
-                          "tbLocation": "100T_HB_04",
-                          "trainId": "15:52_HOB/33S "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel A",
-                  "trains": [
-                      {
-                          "atsTime": 1635796287,
-                          "depArrTime": 1635796377,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "158T_33_01",
-                          "trainId": "15:47_33S/JSQ "
-                      },
-                      {
-                          "atsTime": 1635796108,
-                          "depArrTime": 1635796675,
-                          "destination": "HOB",
-                          "service": 3,
-                          "tbLocation": "195T_33_01",
-                          "trainId": "15:52_33S/HOB "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "09S",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "09S_Station",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511738,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel B",
-                  "trains": [
-                      {
-                          "atsTime": 1635796288,
-                          "depArrTime": 1635796322,
-                          "destination": "33S",
-                          "service": 3,
-                          "tbLocation": "147AT_33_02",
-                          "trainId": "15:42_HOB/33S "
-                      },
-                      {
-                          "atsTime": 1635796289,
-                          "depArrTime": 1635796559,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "121T_HB_03",
-                          "trainId": "15:39_JSQ/33S "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel A",
-                  "trains": [
-                      {
-                          "atsTime": 1635796287,
-                          "depArrTime": 1635796295,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "158T_33_01",
-                          "trainId": "15:47_33S/JSQ "
-                      },
-                      {
-                          "atsTime": 1635796107,
-                          "depArrTime": 1635796593,
-                          "destination": "HOB",
-                          "service": 3,
-                          "tbLocation": "195T_33_01",
-                          "trainId": "15:52_33S/HOB "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "14S",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "14S_Track_B",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511738,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "14S_Track_A",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511738,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel B",
-                  "trains": [
-                      {
-                          "atsTime": 1635796288,
-                          "depArrTime": 1635796417,
-                          "destination": "33S",
-                          "service": 3,
-                          "tbLocation": "147AT_33_02",
-                          "trainId": "15:42_HOB/33S "
-                      },
-                      {
-                          "atsTime": 1635796289,
-                          "depArrTime": 1635796654,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "121T_HB_03",
-                          "trainId": "15:39_JSQ/33S "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel A",
-                  "trains": [
-                      {
-                          "atsTime": 1635796224,
-                          "depArrTime": 1635796497,
-                          "destination": "HOB",
-                          "service": 3,
-                          "tbLocation": "195T_33_01",
-                          "trainId": "15:52_33S/HOB "
-                      },
-                      {
-                          "atsTime": 1635796238,
-                          "depArrTime": 1635796797,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "187T_33_04",
-                          "trainId": "15:57_33S/JSQ "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "23S",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "23S_Track_B",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511738,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "23S_Track_A",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635511738,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Tunnel B",
-                  "trains": [
-                      {
-                          "atsTime": 1635796288,
-                          "depArrTime": 1635796503,
-                          "destination": "33S",
-                          "service": 3,
-                          "tbLocation": "147AT_33_02",
-                          "trainId": "15:42_HOB/33S "
-                      },
-                      {
-                          "atsTime": 1635796289,
-                          "depArrTime": 1635796740,
-                          "destination": "33S",
-                          "service": 2,
-                          "tbLocation": "121T_HB_03",
-                          "trainId": "15:39_JSQ/33S "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Tunnel A",
-                  "trains": [
-                      {
-                          "atsTime": 1635796137,
-                          "depArrTime": 1635796409,
-                          "destination": "HOB",
-                          "service": 3,
-                          "tbLocation": "195T_33_01",
-                          "trainId": "15:52_33S/HOB "
-                      },
-                      {
-                          "atsTime": 1635796238,
-                          "depArrTime": 1635796709,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "187T_33_04",
-                          "trainId": "15:57_33S/JSQ "
-                      }
-                  ]
-              }
-          ]
-      },
-      {
-          "abbrv": "33S",
-          "signinfo": [
-              {
-                  "location": "stationwide",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635810691,
-                  "scrollingText": "",
-                  "scrollingTextTimestamp": 1635810691
-              },
-              {
-                  "location": "33S_Fare_Zone",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1633940464,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "33S_Platform_2",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1633964032,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              },
-              {
-                  "location": "33S_Platform_3",
-                  "overrideText": "",
-                  "overrideTextTimestamp": 1635425311,
-                  "scrollingText": "Masks are still required, even if you are vaccinated. --- Eating, drinking, and smoking not allowed on PATH. --- Motorized bikes/scooters not permitted. --- Non-motorized bikes/scooters: Folded bikes/scooters permitted all times. Non-folding bikes/scooters permitted all times except weekdays 6:30-9:30am and weekdays 3:30-6:30pm. ",
-                  "scrollingTextTimestamp": 1635785820
-              }
-          ],
-          "tracks": [
-              {
-                  "trackId": "Track 1",
-                  "trains": [
-                      {
-                          "atsTime": 1635796238,
-                          "depArrTime": 1635796620,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "187T_33_04",
-                          "trainId": "15:57_33S/JSQ "
-                      },
-                      {
-                          "atsTime": 1635796029,
-                          "depArrTime": 1635797220,
-                          "destination": "JSQ",
-                          "service": 2,
-                          "tbLocation": "",
-                          "trainId": "16:07_33S/JSQ "
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 2",
-                  "trains": [
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      },
-                      {
-                          "atsTime": "",
-                          "depArrTime": "",
-                          "destination": "",
-                          "service": "",
-                          "tbLocation": "",
-                          "trainId": ""
-                      }
-                  ]
-              },
-              {
-                  "trackId": "Track 3",
-                  "trains": [
-                      {
-                          "atsTime": 1635796107,
-                          "depArrTime": 1635796320,
-                          "destination": "HOB",
-                          "service": 3,
-                          "tbLocation": "195T_33_01",
-                          "trainId": "15:52_33S/HOB "
-                      },
-                      {
-                          "atsTime": 1635795737,
-                          "depArrTime": 1635796920,
-                          "destination": "HOB",
-                          "service": 3,
-                          "tbLocation": "",
-                          "trainId": "16:02_33S/HOB "
-                      }
-                  ]
-              }
-          ]
-      }
-  ]
+  "results": [
+    {
+      "consideredStation": "33S",
+      "label": "ToNJ",
+      "target": "JSQ",
+      "messages": [
+        {
+          "secondsToArrival": 132,
+          "arrivalTimeMessage": "2 min",
+          "lineColor": "#FF9900",
+          "headSign": "Journal Square",
+          "lastUpdated": "2020-02-21T15:04:47.529288-05:00"
+        },
+        {
+          "secondsToArrival": 732,
+          "arrivalTimeMessage": "12 min",
+          "lineColor": "#FF9900",
+          "headSign": "Journal Square",
+          "lastUpdated": "2020-02-21T15:04:47.529288-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "HOB",
+      "label": "ToNY",
+      "target": "WTC",
+      "messages": [
+        {
+          "secondsToArrival": 248,
+          "arrivalTimeMessage": "4 min",
+          "lineColor": "#65C100",
+          "headSign": "World Trade Center",
+          "lastUpdated": "2020-02-21T15:04:52.397063-05:00"
+        },
+        {
+          "secondsToArrival": 968,
+          "arrivalTimeMessage": "16 min",
+          "lineColor": "#65C100",
+          "headSign": "World Trade Center",
+          "lastUpdated": "2020-02-21T15:04:52.397063-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "GRV",
+      "label": "ToNJ",
+      "target": "JSQ",
+      "messages": [
+        {
+          "secondsToArrival": 167,
+          "arrivalTimeMessage": "3 min",
+          "lineColor": "#4D92FB,#FF9900",
+          "headSign": "Journal Square via Hoboken",
+          "lastUpdated": "2020-02-22T15:45:59.562598-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "GRV",
+      "label": "ToNY",
+      "target": "EXP",
+      "messages": [
+        {
+          "secondsToArrival": 123,
+          "arrivalTimeMessage": "2 min",
+          "lineColor": "#D93A30",
+          "headSign": "Exchange Place",
+          "lastUpdated": "2020-02-22T15:46:24.456122-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "HAR",
+      "label": "ToNY",
+      "target": "EXP",
+      "messages": [
+        {
+          "secondsToArrival": 903,
+          "arrivalTimeMessage": "15 min",
+          "lineColor": "#D93A30",
+          "headSign": "Exchange Place",
+          "lastUpdated": "2020-02-22T15:46:24.456122-05:00"
+        },
+        {
+          "secondsToArrival": 2103,
+          "arrivalTimeMessage": "35 min",
+          "lineColor": "#D93A30",
+          "headSign": "Exchange Place",
+          "lastUpdated": "2020-02-22T15:46:24.456122-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "NEW",
+      "label": "ToNJ",
+      "target": "JSQ",
+      "messages": [
+        {
+          "secondsToArrival": 379,
+          "arrivalTimeMessage": "6 min",
+          "lineColor": "#4D92FB,#FF9900",
+          "headSign": "Journal Square via Hoboken",
+          "lastUpdated": "2020-02-22T15:46:19.622791-05:00"
+        },
+        {
+          "secondsToArrival": 988,
+          "arrivalTimeMessage": "17 min",
+          "lineColor": "#4D92FB,#FF9900",
+          "headSign": "Journal Square via Hoboken",
+          "lastUpdated": "2020-02-22T15:46:19.622791-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "CHR",
+      "label": "ToNJ",
+      "target": "JSQ",
+      "messages": [
+        {
+          "secondsToArrival": 124,
+          "arrivalTimeMessage": "Delayed",
+          "lineColor": "#4D92FB,#FF9900",
+          "headSign": "Journal Square via Hoboken",
+          "lastUpdated": "2020-02-22T15:46:19.622791-05:00"
+        },
+        {
+          "secondsToArrival": 515,
+          "arrivalTimeMessage": "9 min",
+          "lineColor": "#4D92FB,#FF9900",
+          "headSign": "Journal Square via Hoboken",
+          "lastUpdated": "2020-02-22T15:46:19.622791-05:00"
+        }
+      ]
+    },
+    {
+      "consideredStation": "09S",
+      "label": "ToNJ",
+      "target": "HOB",
+      "messages": [
+        {
+          "secondsToArrival": 88,
+          "arrivalTimeMessage": "2 min",
+          "lineColor": "#4D92FB",
+          "headSign": "Hoboken",
+          "lastUpdated": "2020-02-21T15:04:47.529288-05:00"
+        }
+      ]
+    }
+  ],
+  "requestTimestamp": "2020-02-22T20:46:26"
 }

--- a/test/test_path_new.py
+++ b/test/test_path_new.py
@@ -1,0 +1,34 @@
+import pendulum
+import pytest
+
+from gtfs_realtime_translators.factories import FeedMessage
+from gtfs_realtime_translators.translators.path_new import PathNewGtfsRealtimeTranslator
+from gtfs_realtime_translators.bindings import intersection_pb2 as intersection_gtfs_realtime
+
+
+@pytest.fixture
+def path_new():
+    with open('test/fixtures/path_new.json') as f:
+        raw = f.read()
+    return raw
+
+
+def test_path_data(path_new):
+    translator = PathNewGtfsRealtimeTranslator()
+    with pendulum.test(pendulum.datetime(2020, 2, 22, 12, 0, 0)):
+        message = translator(path_new)
+    assert message.header.gtfs_realtime_version == FeedMessage.VERSION
+    entity = message.entity[0]
+    assert entity.id == '15:55_NWK/WTC'
+    trip_update = entity.trip_update
+    assert trip_update.trip.trip_id == ''
+    assert trip_update.trip.route_id == '862'
+    stop_time_update = trip_update.stop_time_update[0]
+    assert stop_time_update.stop_id == '781718'
+    assert stop_time_update.departure.time == 1635796500
+    assert stop_time_update.arrival.time == 1635796500
+    intersection_trip_update = trip_update.Extensions[intersection_gtfs_realtime.intersection_trip_update]
+    intersection_stop_time_update = stop_time_update.Extensions[intersection_gtfs_realtime.intersection_stop_time_update]
+    assert intersection_stop_time_update.track == "Track H"
+    assert intersection_stop_time_update.stop_name == "Newark"
+    assert intersection_trip_update.headsign == "World Trade Center"

--- a/test/test_path_rail.py
+++ b/test/test_path_rail.py
@@ -3,7 +3,6 @@ import pytest
 
 from gtfs_realtime_translators.factories import FeedMessage
 from gtfs_realtime_translators.translators.path_rail import PathGtfsRealtimeTranslator
-from gtfs_realtime_translators.bindings import intersection_pb2 as intersection_gtfs_realtime
 
 
 @pytest.fixture
@@ -17,18 +16,15 @@ def test_path_data(path_rail):
     translator = PathGtfsRealtimeTranslator()
     with pendulum.test(pendulum.datetime(2020, 2, 22, 12, 0, 0)):
         message = translator(path_rail)
+
     assert message.header.gtfs_realtime_version == FeedMessage.VERSION
+
     entity = message.entity[0]
-    assert entity.id == '15:55_NWK/WTC'
     trip_update = entity.trip_update
     assert trip_update.trip.trip_id == ''
-    assert trip_update.trip.route_id == '862'
+    assert trip_update.trip.route_id == '861'
+
     stop_time_update = trip_update.stop_time_update[0]
-    assert stop_time_update.stop_id == '781718'
-    assert stop_time_update.departure.time == 1635796500
-    assert stop_time_update.arrival.time == 1635796500
-    intersection_trip_update = trip_update.Extensions[intersection_gtfs_realtime.intersection_trip_update]
-    intersection_stop_time_update = stop_time_update.Extensions[intersection_gtfs_realtime.intersection_stop_time_update]
-    assert intersection_stop_time_update.track == "Track H"
-    assert intersection_stop_time_update.stop_name == "Newark"
-    assert intersection_trip_update.headsign == "World Trade Center"
+    assert stop_time_update.stop_id == '781741'
+    assert stop_time_update.departure.time == 1582372920
+    assert stop_time_update.arrival.time == 1582372920

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -17,7 +17,6 @@ from gtfs_realtime_translators.registry import TranslatorRegistry, TranslatorKey
 def test_registry_for_valid_key():
     assert TranslatorRegistry.get('la-metro-old') == LaMetroGtfsRealtimeTranslator
     assert TranslatorRegistry.get('septa-regional-rail') == SeptaRegionalRailTranslator
-    assert TranslatorRegistry.get('septa') == SwiftlyGtfsRealtimeTranslator
     assert TranslatorRegistry.get('cta-subway') == CtaSubwayGtfsRealtimeTranslator
     assert TranslatorRegistry.get('cta-bus') == CtaBusGtfsRealtimeTranslator
     assert TranslatorRegistry.get('mta-subway') == MtaSubwayGtfsRealtimeTranslator

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -1,12 +1,33 @@
 import pytest
 
 from gtfs_realtime_translators.translators import LaMetroGtfsRealtimeTranslator, \
-        SeptaRegionalRailTranslator
+        SeptaRegionalRailTranslator, \
+        SwiftlyGtfsRealtimeTranslator, \
+        CtaSubwayGtfsRealtimeTranslator, \
+        CtaBusGtfsRealtimeTranslator, \
+        MtaSubwayGtfsRealtimeTranslator, \
+        NjtRailGtfsRealtimeTranslator, \
+        NjtBusGtfsRealtimeTranslator, \
+        PathGtfsRealtimeTranslator, \
+        PathNewGtfsRealtimeTranslator, \
+        WcdotGtfsRealTimeTranslator, \
+        MbtaGtfsRealtimeTranslator
 from gtfs_realtime_translators.registry import TranslatorRegistry, TranslatorKeyWarning
 
 def test_registry_for_valid_key():
-    assert TranslatorRegistry.get('la-metro') == LaMetroGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('la-metro-old') == LaMetroGtfsRealtimeTranslator
     assert TranslatorRegistry.get('septa-regional-rail') == SeptaRegionalRailTranslator
+    assert TranslatorRegistry.get('septa') == SwiftlyGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('cta-subway') == CtaSubwayGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('cta-bus') == CtaBusGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('mta-subway') == MtaSubwayGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('njt-rail') == NjtRailGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('njt-bus') == NjtBusGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('path-old') == PathGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('path-new') == PathNewGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('swiftly') == SwiftlyGtfsRealtimeTranslator
+    assert TranslatorRegistry.get('wcdot-bus') == WcdotGtfsRealTimeTranslator
+    assert TranslatorRegistry.get('mbta') == MbtaGtfsRealtimeTranslator
 
 def test_registry_for_invalid_key():
     with pytest.warns(TranslatorKeyWarning):


### PR DESCRIPTION
Renaming the _LA Metro_ to _LA Metro Old_
Renaming _PATH_ to _PATH New_ and restoring the original PATH Translator as _PATH Old_
Deleting VTA as VTA was just a mapping to the Swiftly Translator

(Minor) Bumping up the coverage in `test_registry.py`