### PR TITLE
TRAN-5724 modified track field assignment in mta subway translator

### DIFF
--- a/gtfs_realtime_translators/translators/mta_subway.py
+++ b/gtfs_realtime_translators/translators/mta_subway.py
@@ -39,7 +39,7 @@ class MtaSubwayGtfsRealtimeTranslator:
         headsign = arrival['tripHeadsign']
         scheduled_arrival_time = arrival['serviceDay'] + arrival['scheduledArrival']
         scheduled_departure_time = arrival['serviceDay'] + arrival['scheduledDeparture']
-        track = arrival['track']
+        track = arrival.get('track', '')
 
         return TripUpdate.create(entity_id=entity_id,
                                 arrival_time=arrival_time,


### PR DESCRIPTION
Modified track field assignment for the mta-subway translator to avoid a KeyError when the track field is absent in any mta feeds.