### PR TITLE
Revised MBTA arrival processing logic

### DIFF
--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -31,8 +31,8 @@ class MbtaGtfsRealtimeTranslator:
             raw_arrival_time = attributes['arrival_time']
             raw_departure_time = attributes['departure_time']
 
-            if cls.should_capture_prediction(raw_arrival_time, raw_departure_time):
-                arrival_time, departure_time = cls.set_arrival_and_departure_times(
+            if cls.__should_capture_prediction(raw_arrival_time, raw_departure_time):
+                arrival_time, departure_time = cls.__set_arrival_and_departure_times(
                     raw_arrival_time, raw_departure_time)
                 trip_update = TripUpdate.create(
                     entity_id=entity_id,
@@ -46,17 +46,17 @@ class MbtaGtfsRealtimeTranslator:
 
         return trip_updates
 
-    @staticmethod
-    def set_arrival_and_departure_times(raw_arrival_time, raw_departure_time):
-        departure_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
+    @classmethod
+    def __set_arrival_and_departure_times(cls, raw_arrival_time, raw_departure_time):
+        departure_time = cls.__to_unix_time(
             raw_departure_time)
         if raw_arrival_time:
-            arrival_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
+            arrival_time = cls.__to_unix_time(
                 raw_arrival_time)
         else:
             arrival_time = departure_time
         return arrival_time, departure_time
 
-    @staticmethod
-    def should_capture_prediction(raw_departure_time):
+    @classmethod
+    def __should_capture_prediction(cls, raw_departure_time):
         return raw_departure_time

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -48,19 +48,15 @@ class MbtaGtfsRealtimeTranslator:
 
     @staticmethod
     def set_arrival_and_departure_times(raw_arrival_time, raw_departure_time):
+        departure_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
+            raw_departure_time)
         if raw_arrival_time:
             arrival_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
                 raw_arrival_time)
-        if raw_departure_time:
-            departure_time = MbtaGtfsRealtimeTranslator.__to_unix_time(
-                raw_departure_time)
-        if not raw_arrival_time:
+        else:
             arrival_time = departure_time
-        if not raw_departure_time:
-            departure_time = arrival_time
         return arrival_time, departure_time
 
     @staticmethod
-    def should_capture_prediction(raw_arrival_time, raw_departure_time):
-        should_capture = raw_arrival_time or raw_departure_time
-        return should_capture
+    def should_capture_prediction(raw_departure_time):
+        return raw_departure_time

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -31,7 +31,7 @@ class MbtaGtfsRealtimeTranslator:
             raw_arrival_time = attributes['arrival_time']
             raw_departure_time = attributes['departure_time']
 
-            if cls.__should_capture_prediction(raw_arrival_time, raw_departure_time):
+            if cls.__should_capture_prediction(raw_departure_time):
                 arrival_time, departure_time = cls.__set_arrival_and_departure_times(
                     raw_arrival_time, raw_departure_time)
                 trip_update = TripUpdate.create(

--- a/test/test_mbta.py
+++ b/test/test_mbta.py
@@ -79,9 +79,9 @@ def test_mbta_bus_realtime_arrival_no_departure(mbta_bus):
 
     assert message.header.gtfs_realtime_version == FeedMessage.VERSION
 
-    assert entity.id == '4'
+    assert entity.id == '5'
     assert entity.trip_update.trip.route_id == '66'
-    assert entity.trip_update.trip.trip_id == '49181350'
+    assert entity.trip_update.trip.trip_id == '49181351'
     assert stop_time_update.stop_id == '1357'
-    assert stop_time_update.arrival.time == 1632779478
-    assert stop_time_update.departure.time == 1632779478
+    assert stop_time_update.arrival.time == 1632780015
+    assert stop_time_update.departure.time == 1632780015


### PR DESCRIPTION
- an MBTA arrival will only be processed if it contains a non-null departure time. 
- changed static methods to class methods

This differs from the previous logic where an arrival would be processed as long as it contained either an `arrival_time` or a `departure_time`. Now, in the case where an arrival contains an `arrival_time` but no `departure_time`, it will not be processed.