### PR TITLE
TRAN-6409 updated septa RR translator to accomodate change in stop name

### DIFF
--- a/gtfs_realtime_translators/translators/septa_regional_rail.py
+++ b/gtfs_realtime_translators/translators/septa_regional_rail.py
@@ -16,7 +16,7 @@ class SeptaRegionalRailTranslator:
         'Chestnut Hill East': 'CHE',
         'Chestnut Hill West': 'CHW',
         'Lansdale/Doylestown': 'LAN',
-        'Media/Elwyn': 'MED',
+        'Media/Wawa': 'MED',
         'Fox Chase': 'FOX',
         'Manayunk/Norristown': 'NOR',
         'Paoli/Thorndale': 'PAO',


### PR DESCRIPTION
Updates `septa-regional-rail` translator to accommodate `Elwyn` station's name change to `Wawa` station. This necessitates a change in the `Media/Elwyn` route name to `Media/Wawa`.