### PR TITLE
TRAN-6945 add direction_id to mbta translator

### DIFF
--- a/gtfs_realtime_translators/factories/factories.py
+++ b/gtfs_realtime_translators/factories/factories.py
@@ -36,6 +36,7 @@ class TripUpdate:
         trip_id = kwargs.get('trip_id', None)
         route_id = kwargs.get('route_id', None)
         stop_id = kwargs['stop_id']
+        direction_id = kwargs.get('direction_id', None)
 
         if 'arrival_delay' in kwargs:
             arrival_delay = kwargs.get('arrival_delay',None)
@@ -61,7 +62,8 @@ class TripUpdate:
         custom_status = kwargs.get('custom_status', None)
 
         trip_descriptor = gtfs_realtime.TripDescriptor(trip_id=trip_id,
-                                                       route_id=route_id)
+                                                       route_id=route_id,
+                                                       direction_id=direction_id)
 
         stop_time_update = gtfs_realtime.TripUpdate.StopTimeUpdate(arrival=arrival,
                                                                    departure=departure,

--- a/gtfs_realtime_translators/translators/mbta.py
+++ b/gtfs_realtime_translators/translators/mbta.py
@@ -30,6 +30,7 @@ class MbtaGtfsRealtimeTranslator:
             trip_id = relationships['trip']['data']['id']
             raw_arrival_time = attributes['arrival_time']
             raw_departure_time = attributes['departure_time']
+            direction_id = attributes['direction_id']
 
             if cls.__should_capture_prediction(raw_departure_time):
                 arrival_time, departure_time = cls.__set_arrival_and_departure_times(
@@ -40,7 +41,8 @@ class MbtaGtfsRealtimeTranslator:
                     stop_id=stop_id,
                     trip_id=trip_id,
                     arrival_time=arrival_time,
-                    departure_time=departure_time
+                    departure_time=departure_time,
+                    direction_id=direction_id
                 )
                 trip_updates.append(trip_update)
 


### PR DESCRIPTION
The purpose of this PR is to add support for ingesting the `direction_id` field for MBTA realtime feeds. The `direction_id` field is part of the `TripDescriptor` message, which exists within each `TripUpdate` message.

https://developers.google.com/transit/gtfs-realtime/reference#message-tripdescriptor