### PR TITLE
TRAN-7436: remove leading 0s of route_id

### DIFF
--- a/gtfs_realtime_translators/translators/wcdot_bus.py
+++ b/gtfs_realtime_translators/translators/wcdot_bus.py
@@ -23,6 +23,8 @@ class WcdotGtfsRealTimeTranslator:
             trip = trip_update.get('trip')
             trip_id = trip.get('trip_id')
             route_id = trip.get('route_id')
+            if route_id:
+                route_id = route_id.lstrip('0')
             stop_time_update = trip_update.get('stop_time_update')
             for update in stop_time_update:
                 stop_id = update.get("stop_id")


### PR DESCRIPTION
This PR removes the leading zeroes from the `route_id` in `wcdot-bus` feeds.