### PR TITLE
Harmonize license to Apache-2.0 (fixes #63)

### DIFF
--- a/gtfs_realtime_translators/__version__.py
+++ b/gtfs_realtime_translators/__version__.py
@@ -1,1 +1,2 @@
 __version__ = '1.1.0'
+__license__ = "Apache-2.0"

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
         f'{PACKAGE_ROOT}.bindings',
         f'{PACKAGE_ROOT}.validators',
     ],
-    license='MIT license',
+    license=about['__license__'],
     install_requires=requirements,
 )


### PR DESCRIPTION
This PR fixes the contradiction licensing information. I assume Apache-2.0 as stated in license.txt and in the [intersection bolg](https://ixn.intersection.com/found-in-translation-announcing-a-library-of-gtfs-realtime-translators-1d196857dded) is the correct one. Fixes #63.