### PR TITLE
CTA: Parse Vehicle Number into Int()

### DIFF
--- a/gtfs_realtime_translators/translators/cta_subway.py
+++ b/gtfs_realtime_translators/translators/cta_subway.py
@@ -51,9 +51,9 @@ class CtaSubwayGtfsRealtimeTranslator:
                                                 parsed_prediction_time)
         scheduled_interval = cls.__get_scheduled_interval(is_scheduled,
                                                           prediction['schInt'])
-        
+
         route_icon = cls.__get_route_icon(prediction['flags'], headsign)
-        run_number = prediction['rn']
+        run_number = int(prediction['rn'])
 
         return TripUpdate.create(entity_id=entity_id,
                                  route_id=route_id,
@@ -80,11 +80,11 @@ class CtaSubwayGtfsRealtimeTranslator:
             scheduled_interval_seconds = int(scheduled_interval) * 60
             return scheduled_interval_seconds
         return None
-    
+
     @classmethod
     def __get_route_icon(cls, flags, headsign):
         if flags and flags.lower() == 'h':
-            return 'holiday' 
+            return 'holiday'
         if headsign and headsign.lower() in ["midway", "o'hare"]:
             return 'airport'
         return None


### PR DESCRIPTION
# Description 

the prediction[‘rn’] field from the cta API being a string, but the `run_number` type is expected to be an int. This PR attempts to cast run_number into an `int`.