### PR TITLE
TRAN-9728: CTA realtime translator for delayed trips

### DIFF
--- a/gtfs_realtime_translators/registry/registry.py
+++ b/gtfs_realtime_translators/registry/registry.py
@@ -6,7 +6,7 @@ from gtfs_realtime_translators.translators import LaMetroGtfsRealtimeTranslator,
     PathNewGtfsRealtimeTranslator, SwiftlyGtfsRealtimeTranslator, WcdotGtfsRealTimeTranslator, \
     NjtBusGtfsRealtimeTranslator, MbtaGtfsRealtimeTranslator, MnmtGtfsRealtimeTranslator, \
     MartaRailGtfsRealtimeTranslator, NjtRailJsonGtfsRealtimeTranslator, \
-    NjtBusJsonGtfsRealtimeTranslator, PathRailNewGtfsRealtimeTranslator
+    NjtBusJsonGtfsRealtimeTranslator, PathRailNewGtfsRealtimeTranslator, CtaGtfsRealtimeTranslator
 
 
 class TranslatorKeyWarning(Warning):
@@ -19,6 +19,7 @@ class TranslatorRegistry:
         'septa-regional-rail': SeptaRegionalRailTranslator,
         'cta-subway': CtaSubwayGtfsRealtimeTranslator,
         'cta-bus': CtaBusGtfsRealtimeTranslator,
+        'cta-gtfs-rt': CtaGtfsRealtimeTranslator,
         'mta-subway': MtaSubwayGtfsRealtimeTranslator,
         'njt-rail': NjtRailGtfsRealtimeTranslator,
         'njt-rail-json': NjtRailJsonGtfsRealtimeTranslator,

--- a/gtfs_realtime_translators/translators/__init__.py
+++ b/gtfs_realtime_translators/translators/__init__.py
@@ -7,6 +7,7 @@ from .njt_bus import NjtBusGtfsRealtimeTranslator
 from .njt_bus_json import NjtBusJsonGtfsRealtimeTranslator
 from .cta_subway import CtaSubwayGtfsRealtimeTranslator
 from .cta_bus import CtaBusGtfsRealtimeTranslator
+from .cta_realtime import CtaGtfsRealtimeTranslator
 from .path_rail import PathGtfsRealtimeTranslator
 from .path_new import PathNewGtfsRealtimeTranslator
 from .swiftly import SwiftlyGtfsRealtimeTranslator

--- a/gtfs_realtime_translators/translators/cta_realtime.py
+++ b/gtfs_realtime_translators/translators/cta_realtime.py
@@ -1,0 +1,28 @@
+from google.transit import gtfs_realtime_pb2 as gtfs_realtime
+
+from gtfs_realtime_translators.bindings import intersection_pb2 as intersection_gtfs_realtime
+
+
+class CtaGtfsRealtimeTranslator:
+    """CTA signals a delayed vehicle via NO_DATA + no arrival.time, per Metra's convention."""
+
+    def __call__(self, data):
+        feed_message = gtfs_realtime.FeedMessage()
+        feed_message.ParseFromString(data)
+
+        for entity in feed_message.entity:
+            if not entity.HasField('trip_update'):
+                continue
+            trip_update = entity.trip_update
+            if self.__is_delayed(trip_update):
+                trip_update.Extensions[intersection_gtfs_realtime.intersection_trip_update].custom_status = 'DELAYED'
+
+        return feed_message
+
+    @staticmethod
+    def __is_delayed(trip_update):
+        return any(
+            stop_time_update.schedule_relationship == gtfs_realtime.TripUpdate.StopTimeUpdate.NO_DATA
+            and not stop_time_update.arrival.HasField('time')
+            for stop_time_update in trip_update.stop_time_update
+        )

--- a/test/test_cta_realtime.py
+++ b/test/test_cta_realtime.py
@@ -1,0 +1,58 @@
+from google.transit import gtfs_realtime_pb2 as gtfs_realtime
+
+from gtfs_realtime_translators.bindings import intersection_pb2 as intersection_gtfs_realtime
+from gtfs_realtime_translators.translators import CtaGtfsRealtimeTranslator
+
+
+def _make_feed(stop_time_updates):
+    feed = gtfs_realtime.FeedMessage()
+    feed.header.gtfs_realtime_version = '2.0'
+    entity = feed.entity.add()
+    entity.id = '1'
+    entity.trip_update.trip.trip_id = 'trip1'
+    for stop_id, schedule_relationship, arrival_time in stop_time_updates:
+        stop_time_update = entity.trip_update.stop_time_update.add()
+        stop_time_update.stop_id = stop_id
+        stop_time_update.schedule_relationship = schedule_relationship
+        if arrival_time is not None:
+            stop_time_update.arrival.time = arrival_time
+    return feed.SerializeToString()
+
+
+def test_cta_realtime_marks_no_data_trip_as_delayed():
+    data = _make_feed([
+        ('stop1', gtfs_realtime.TripUpdate.StopTimeUpdate.NO_DATA, None),
+    ])
+
+    translator = CtaGtfsRealtimeTranslator()
+    message = translator(data)
+
+    trip_update = message.entity[0].trip_update
+    custom_status = trip_update.Extensions[intersection_gtfs_realtime.intersection_trip_update].custom_status
+    assert custom_status == 'DELAYED'
+
+
+def test_cta_realtime_leaves_scheduled_trip_unmarked():
+    data = _make_feed([
+        ('stop1', gtfs_realtime.TripUpdate.StopTimeUpdate.SCHEDULED, 11111),
+    ])
+
+    translator = CtaGtfsRealtimeTranslator()
+    message = translator(data)
+
+    trip_update = message.entity[0].trip_update
+    custom_status = trip_update.Extensions[intersection_gtfs_realtime.intersection_trip_update].custom_status
+    assert custom_status == ''
+
+
+def test_cta_realtime_no_data_with_arrival_time_is_not_delayed():
+    data = _make_feed([
+        ('stop1', gtfs_realtime.TripUpdate.StopTimeUpdate.NO_DATA, 11111),
+    ])
+
+    translator = CtaGtfsRealtimeTranslator()
+    message = translator(data)
+
+    trip_update = message.entity[0].trip_update
+    custom_status = trip_update.Extensions[intersection_gtfs_realtime.intersection_trip_update].custom_status
+    assert custom_status == ''


### PR DESCRIPTION
This PR adds a **CTA-specific translator** that recreates CTA's convention for signaling a delayed vehicle in its native **GTFS-Realtime** feed, since GTFS-RT has no explicit delay field.

`CtaGtfsRealtimeTranslator` parses CTA's raw GTFS-RT protobuf bytes and sets `custom_status = 'DELAYED'` on any `trip_update` where a stop has `schedule_relationship == 'NO_DATA'` and no `arrival.time`, leaving the rest of the feed unchanged.

The translator is registered under the key `cta-gtfs-rt` and is scoped to **CTA only**, since other agencies' feeds may use `NO_DATA` for unrelated reasons.
